### PR TITLE
Updated installation steps and Makefile

### DIFF
--- a/e2edemo/Makefile
+++ b/e2edemo/Makefile
@@ -84,12 +84,12 @@ deploy-all: deploy-bmc deploy-bmv deploy-xcall deploy-dapp
 start-nodes:
 	@ echo ">>> Start nodes" ; \
 	cd docker; \
-	docker-compose up -d
+	docker compose up -d
 
 stop-nodes:
 	@ echo ">>> Stop nodes" ; \
 	cd docker; \
-	docker-compose down
+	docker compose down
 
 setup-node:
 	@ echo ">>> Setup ICON node" ; \

--- a/e2edemo/README.md
+++ b/e2edemo/README.md
@@ -10,9 +10,12 @@ In this demo, you will learn how to perform end-to-end testing between ICON and 
 
 To run the demo, the following software needs to be installed.
 
- * Node.js 18 (LTS) \[[download](https://nodejs.org/en/download/)\]
- * Docker-compose \[[download](https://docs.docker.com/compose/install/)\]
- * OpenJDK 11 or above \[[download](https://adoptium.net/)\]
+* Node.js 18 (LTS) \[[download](https://nodejs.org/en/download/)\]
+* Docker compose (V2) \[[download](https://docs.docker.com/compose/install/)\]
+* OpenJDK 11 or above \[[download](https://adoptium.net/)\]
+* jq \[[download](https://github.com/stedolan/jq)\]
+* go \[[download](https://go.dev/doc/install)\]
+
 
 ## Install required packages
 


### PR DESCRIPTION
Updated installation steps to add necessary packages and `Makefile` to upgrade from `docker-compose` V1 to `docker compose` v2

```bash
$ sudo make start-nodes
>>> Start nodes
[+] Running 3/3
 ⠿ Network docker_default      Created                                     0.0s
 ⠿ Container icon-node         Started                                     0.5s
 ⠿ Container docker-ganache-1  Started                                     0.5s

$ sudo make stop-nodes 
>>> Stop nodes
[+] Running 3/3
 ⠿ Container docker-ganache-1  Removed                                     0.4s
 ⠿ Container icon-node         Removed                                     0.4s
 ⠿ Network docker_default      Removed                                     0.2s
```