### PR TITLE
Update start.sh to enable rpcIncludeDebug

### DIFF
--- a/e2edemo/docker/icon/config/start.sh
+++ b/e2edemo/docker/icon/config/start.sh
@@ -23,6 +23,8 @@ start_chain() {
         --normal_tx_pool 1000 \
         --db_type rocksdb \
         --role 3
+    goloop system config rpcIncludeDebug true
+    
   fi
   goloop chain start 0x${CID}
 }

--- a/e2edemo/docker/icon/config/start.sh
+++ b/e2edemo/docker/icon/config/start.sh
@@ -24,7 +24,6 @@ start_chain() {
         --db_type rocksdb \
         --role 3
     goloop system config rpcIncludeDebug true
-    
   fi
   goloop chain start 0x${CID}
 }


### PR DESCRIPTION
Updated the script at `e2edemo/docker/icon/config/start.sh` to enable the `rpcIncludeDebug` configuration.

This change will allow the use of the `debug_getTrace` rpc method on the node