### PR TITLE
Consider rollback case when calling getFee() method

### DIFF
--- a/e2edemo/scripts/demo_dapp.ts
+++ b/e2edemo/scripts/demo_dapp.ts
@@ -80,10 +80,11 @@ function isEVMChain(chain: any) {
 
 async function sendMessageFromDApp(src: string, srcChain: any, dstChain: any, msg: string,
                                    rollback?: string) {
+  const isRollback = rollback ? true : false;
   if (isIconChain(srcChain)) {
     const iconNetwork = IconNetwork.getNetwork(src);
     const xcallSrc = new XCall(iconNetwork, srcChain.contracts.xcall);
-    const fee = await xcallSrc.getFee(dstChain.network, false);
+    const fee = await xcallSrc.getFee(dstChain.network, isRollback);
     console.log('fee=' + fee);
 
     const dappSrc = new DAppProxy(iconNetwork, srcChain.contracts.dapp);
@@ -101,7 +102,7 @@ async function sendMessageFromDApp(src: string, srcChain: any, dstChain: any, ms
       });
   } else if (isEVMChain(srcChain)) {
     const xcallSrc = await ethers.getContractAt('CallService', srcChain.contracts.xcall);
-    const fee = await xcallSrc.getFee(dstChain.network, false);
+    const fee = await xcallSrc.getFee(dstChain.network, isRollback);
     console.log('fee=' + fee);
 
     const dappSrc = await ethers.getContractAt('DAppProxySample', srcChain.contracts.dapp);


### PR DESCRIPTION
getFee() method in e2e demo script receives rollback as false by default, because of which sendCallMessage with rollback data fails with insufficient fee error.