### PR TITLE
Downgrade node version temporarily to fix hardhat compile failure

### DIFF
--- a/.github/workflows/run-e2edemo.yml
+++ b/.github/workflows/run-e2edemo.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup node 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.15
           cache: 'npm'
           cache-dependency-path: e2edemo/package-lock.json
 

--- a/e2edemo/scripts/setup/deploy_xcall.ts
+++ b/e2edemo/scripts/setup/deploy_xcall.ts
@@ -7,7 +7,7 @@ const deployments = Deployments.getDefault();
 
 async function deploy_xcall_java(target: string, chain: any) {
   const iconNetwork = IconNetwork.getNetwork(target);
-  const content = Jar.readFromFile(JAVASCORE_PATH, "xcall", "0.6.1");
+  const content = Jar.readFromFile(JAVASCORE_PATH, "xcall", "0.6.2");
   const xcall = new Contract(iconNetwork)
   const deployTxHash = await xcall.deploy({
     content: content,


### PR DESCRIPTION
According to https://github.com/NomicFoundation/hardhat/issues/3877, the random failure of `hardhat compile` in github CI workflow is due to the recent update of node v18.16 LTS.

Thus fix the problem temporarily by downgrading the node version to v18.15.